### PR TITLE
Enable user notifications on first run

### DIFF
--- a/UrbanAirshipPlugin/src/com/adenda/plugin/urbanairship/AdendaApplication.java
+++ b/UrbanAirshipPlugin/src/com/adenda/plugin/urbanairship/AdendaApplication.java
@@ -30,8 +30,6 @@ public class AdendaApplication extends Application {
                 AdendaApplication.this.onAirshipReady(airship, isFirstRun);
             }
         });
-        
-        UAirship.shared().getPushManager().setUserNotificationsEnabled(true);
     }
 
     /**
@@ -51,6 +49,10 @@ public class AdendaApplication extends Application {
         }
 
         airship.getPushManager().setNotificationFactory(factory);
+
+        if (isFirstRun) {
+            airship.getPushManager().setUserNotificationsEnabled(true);
+        }
     }
 
     /**


### PR DESCRIPTION
Moves enabling user notifications to the onAirshipReady method during first run. This allows to turn it off without the application overriding the setting. Useful if the app provides some sort of notification toggle in the settings page. It is ok to only call it once because the value is persisted between app runs.
